### PR TITLE
Update lower Kelvin range to 1500

### DIFF
--- a/lib/lifx-light.js
+++ b/lib/lifx-light.js
@@ -473,7 +473,7 @@ LightItem.prototype.parseColorTemp = function parseColorTemp(input, output) {
     return false;
 
   // Round the values and make sure that they are in the valid range
-  output.kelvin = limitValue(Math.round(kelvin), 2000, 10000);
+  output.kelvin = limitValue(Math.round(kelvin), 1500, 10000);
 
   return true;
 }


### PR DESCRIPTION
The new Lifx Mini D (Day & Dusk) bulbs can go down to 1500 Kelvin. The lower value needs to be updated in order to support them.